### PR TITLE
set answeredByTeacher only if teacher in specific course

### DIFF
--- a/Application/Services/QuestionService.cs
+++ b/Application/Services/QuestionService.cs
@@ -7,6 +7,7 @@ using Domain.DTO.Response;
 using Domain.Entities;
 using Infrastructure.Repositories;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace Application.Services;
 
@@ -66,20 +67,18 @@ public class QuestionService : BaseService, IQuestionService
 
     private async Task UpdatingAnsweredByTeacherField(QuestionDetailedDTO questionDTO)
     {
-        var usernames = questionDTO.Answers?
+        var answersUsernames = questionDTO.Answers?
             .Select(a => a.UserName)
             .ToList();
 
-        var teachers = await _userManager
-            .GetUsersInRoleAsync(DomainRoles.TEACHER);
-
-        var teacherUsernames = teachers
-            .Select(u => u.UserName)
-            .ToHashSet();
+        var teachersUsernames = await _userManager.Users
+        .Where(u => u.Subjects.Any(s => s.Id == questionDTO.SubjectId))
+        .Select(u => u.UserName)
+        .ToListAsync();
 
         foreach (var answer in questionDTO.Answers ?? [])
         {
-            if (teacherUsernames.Contains(answer.UserName))
+            if (teachersUsernames.Contains(answer.UserName))
             {
                 answer.AnsweredByTeacher = true;
             }

--- a/Infrastructure/Repositories/QuestionRepository.cs
+++ b/Infrastructure/Repositories/QuestionRepository.cs
@@ -181,7 +181,8 @@ public class QuestionRepository : IQuestionRepository
         }
 
         var searchStrings = searchDTO.SearchString.Split(
-            [' '],
+            //Build error (on Mac) if not explicitly typing the space, i.e new char[] { ' ' } or new string[] { " " },
+            new char[] { ' ' },
             StringSplitOptions.RemoveEmptyEntries);
 
         foreach (var word in searchStrings)

--- a/Infrastructure/Seeds/SeedQAPlatformDBDevelopment.cs
+++ b/Infrastructure/Seeds/SeedQAPlatformDBDevelopment.cs
@@ -167,9 +167,6 @@ public static class SeedQAPlatformDBDevelopment
             await userManager.AddToRoleAsync(user, DomainRoles.USER);
             await userManager.AddToRoleAsync(user, DomainRoles.TEACHER);
 
-            var rangeBottom = RandomInt(0, subjects.Count);
-            var rangeTop = RandomInt(rangeBottom, subjects.Count);
-
             for (int j = 0; j < subjects.Count; j++)
             {
                 if (RandomInt(0, 11) > 7)


### PR DESCRIPTION
I  apologize for nightly contribution. Got up and saw something  in the code and did only a few changes.

This PR changes the UpdatingAnsweredByTeacherField method to only set answeredByTeacher key to true if the answers' usernames' matches a username of the answer's related Subject's teacher, instead of any teacher.

To test that it worked I changed the seed a bit and assigned some teachers to subjects and gave some answers a userId belonging to that answer's related Subject's Teacher.

I then reseeded my db and requested questionDetails and got an answer array where one answeredByTeacher was true. I checked in db and the username who posted the answer was really a teacher in the related Subject.

Also, I got a weird build error for using non typed argument for a string Split method. Fixed that an added a comment. Maybe it is a Mac specific thing.
